### PR TITLE
Added headless option.

### DIFF
--- a/supbot2.py
+++ b/supbot2.py
@@ -79,6 +79,7 @@ cookies = sesh.post(atc_url, headers=headers, data=data).cookies
 
 option = webdriver.ChromeOptions()
 option.add_argument("--disable-blink-features=AutomationControlled")
+option.headless = True # Option to open up chrome in headless mode, better performance by an average of 3 sec.
 driver = webdriver.Chrome(options=option)
 #driver.execute_script("Object.defineProperty(navigator, 'webdriver', {get: () => undefined})")
 #driver.execute_cdp_cmd('Network.setUserAgentOverride', {"userAgent": 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.53 Safari/537.36'})


### PR DESCRIPTION
Option to run Chrome in headless mode. Improves performance by an avergae of 3 seconds. Must run once without headless mode to bypass captcha, then can run in headless mode as it shouldn't ask for the captcha again.